### PR TITLE
Remove optional dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
   <run_depend>rosjava_core</run_depend>
   <run_depend>rosjava_extras</run_depend>
   <run_depend>zeroconf_jmdns_suite</run_depend>
-  <run_depend>rocon_rosjava_core</run_depend>
 
   <export>
     <metapackage/>

--- a/rosjava.rosinstall
+++ b/rosjava.rosinstall
@@ -13,9 +13,4 @@
 {'git': {'local-name': 'rosjava_extras', 'version': 'kinetic', 'uri':'https://github.com/rosjava/rosjava_extras'}},
 {'git': {'local-name': 'zeroconf_jmdns_suite', 'version': 'kinetic', 'uri':'https://github.com/rosjava/zeroconf_jmdns_suite'}},
 {'git': {'local-name': 'rosjava', 'version': 'kinetic', 'uri':'https://github.com/rosjava/rosjava.git'}},
-# Rocon rosjava
-{'git': {'local-name': 'rocon_rosjava_core', 'version': 'indigo', 'uri':'https://github.com/robotics-in-concert/rocon_rosjava_core'}},
-# Temporary requirements
-#   Till 1.11 is released - http://www.ros.org/debbuild/indigo.html?q=ros_comm_msgs
-{'git': {'local-name': 'ros_comm_msgs', 'version': 'indigo-devel', 'uri':'https://github.com/ros/ros_comm_msgs.git'}},
 ]


### PR DESCRIPTION
Temporarily stop making `rocon_rosjava_core` a dependency, until it gets updated for kinetic.

Meanwhile, it can still be used by installing it as a dependency of projects and applications that use it. 

Also while at it, remove no longer necessary source dep (resolved a while back).

@stonier I'd like your input on this one.